### PR TITLE
Containerize borg and perform more pre-installation checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Attempts will be made to tabulate the supported versions of datalab with each re
 
 | This repository version | *datalab* version |
 |---|---|
-| v0.1.x | v0.4.x |
-
+| v0.1.x | v0.4.x  |
+| v0.2.x | v0.4.x  |
+| v0.3.x | v0.5.x+ |
 
 
 ## Overview
@@ -119,18 +120,19 @@ These files contain the desired *datalab* settings:
    file (e.g., keys to external integration with GitHub, ORCID).
 3. `./vaults/datalab/.env`: any variables required by the web app.
 4. `./vaults/datalab/.ssh` (OPTIONAL): any SSH keys and config required to be mounted into the server container. These files should each be individually encrypted.
+5. `./vaults/borg/.ssh` (OPTIONAL): any SSH keys or known hosts required to configure the borg backup system. These files should be individually encrypted.
 
 It is recommended that you version control these files **with encryption** and commit it to your
 fork.
 To encrypt them, you can run
 
 ```shell
-ansible-vault encrypt inventory.yml vaults/datalab/prod_config.json vaults/datalab/.env vaults/datalab/.env_server vaults/datalab/.ssh/*
+ansible-vault encrypt inventory.yml vaults/datalab/prod_config.json vaults/datalab/.env vaults/datalab/.env_server vaults/datalab/.ssh/* vaults/borg/.ssh/*
 ```
 
 and provide a password when prompted (which will then need to be kept safe and
-used every time the Ansible playbook is run). Omit the final SSH wildcard if no
-SSH keyse are required.
+used every time the Ansible playbook is run). Omit the optional SSH wildcards if no
+SSH keys are required.
 You should never commit these files directly without encryption.
 
 Once all these configuration steps have been performed, we can try to execute

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ ungrouped:
       api_url: <desired_datalab_api_url>
       app_url: <desired_datalab_app_url>
       # Additional optional settings:
-      mount_data_disk: <disk device file location, e.g., /dev/sda, /dev/sdb or otherwise>
+      mount_data_disk: <disk device file location, e.g., /dev/sda, /dev/sdb or otherwise or a full fstab configuration, e.g., `UUID=aaaa-bbbb-ccc>
       data_disk_type: <the fstype of the data disk, defaults to 'xfs'
       borg_encryption_passphrase: <the passphrase for the borg encryption>
       borg_remote_path: <the command to run borg on the repository (e.g., borg1 vs borg2)>

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -5,6 +5,9 @@
     # root behaves differently than other users; set home dir accordingly
     ansible_user_home_dir: "{{ '/' + ansible_ssh_user if ansible_ssh_user == 'root' else '/home/' + ansible_ssh_user }}"
   roles:
+    - role: preflight
+      name: Check if the system is ready for the playbook
+      tags: [setup]
     - role: setup
       name: Run OS and disk set up tasks
       tags: [setup]

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -22,13 +22,13 @@
       tags: [setup, ssl]
     - role: datalab
       name: Build and launch datalab services
-      tags: [deploy]
+      tags: [setup, deploy]
     - role: nginx
       name: Launch nginx container with autorenewing certbot
       tags: [setup, maintenance, ssl]
     - role: borg
       name: Configure borg(matic) and remote backups
-      tags: [borg, setup]
+      tags: [borg]
 
   tasks:
     - name: Keep all packages up-to-date

--- a/ansible/roles/borg/files/Dockerfile
+++ b/ansible/roles/borg/files/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-alpine AS builder
+WORKDIR /app
+RUN apk add --no-cache borgbackup mongodb-tools openssh
+RUN pip install --user borgmatic
+ENV PATH="$PATH:/root/.local/bin"
+
+COPY config.yaml /etc/borgmatic/config.yaml
+
+CMD ["borgmatic", "--verbosity", "1", "--config", "/etc/borgmatic/config.yaml"]

--- a/ansible/roles/borg/tasks/main.yml
+++ b/ansible/roles/borg/tasks/main.yml
@@ -1,44 +1,31 @@
 ---
-- name: Install borg
-  become: true
-  ansible.builtin.apt:
-    name:
-      - borgbackup
-      - pipx
-    state: present
+- name: Synchronize borgmatic files to remote
+  ansible.posix.synchronize:
+    src: "{{ role_path }}/files/"
+    dest: "{{ ansible_user_home_dir }}/borgmatic"
 
-- name: Make sure pipx install dir is on PATH
-  ansible.builtin.shell:
-    cmd: pipx ensurepath
-    executable: /bin/bash
-  register: pipx_ensurepath
-  changed_when: '"Success!" in pipx_ensurepath.stdout'
-  failed_when: pipx_ensurepath.rc != 0
+- name: Check whether ssh config exists
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/vaults/borg/.ssh/id_ed25519"
+  register: ssh_config
+  delegate_to: localhost
 
-- name: Install borgmatic with pipx
-  community.general.pipx:
-    name: borgmatic
-    source: borgmatic ~= 1.8, < 2
-    state: present
+- name: Set fact for whether borg ssh config exists
+  ansible.builtin.set_fact:
+    ssh_config_defined: "{{ ssh_config.stat.exists }}"
 
-- name: Install MongoDB tools
-  become: true
-  ansible.builtin.apt:
-    deb: https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-x86_64-100.10.0.deb
-
-- name: Ensure /etc/borgmatic exists
-  become: true
-  ansible.builtin.file:
-    path: /etc/borgmatic
-    state: directory
+- name: Sync local ssh config vault remote
+  when: ssh_config_defined
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/vaults/borg/.ssh/"
+    dest: "{{ ansible_user_home_dir }}/borgmatic/.ssh"
     mode: "0700"
-    owner: "{{ ansible_ssh_user }}"
 
-- name: Add Borgmatic configuration
+- name: Render Borgmatic configuration
   become: true
   ansible.builtin.template:
     src: config.yaml.j2
-    dest: /etc/borgmatic/config.yaml
+    dest: "{{ ansible_user_home_dir }}/borgmatic/config.yaml"
     mode: "0600"
     owner: "{{ ansible_ssh_user }}"
 
@@ -54,6 +41,7 @@
         - echo "`date` - Starting backup."
       mongodb_databases:
         - name: all
+          hostname: datalab-database-1
           port: 27017
     borgmatic_timer: cron
     borg_retention_policy:
@@ -69,9 +57,19 @@
     borg_ssh_command: ssh
     borg_lock_wait_time: 5
 
+- name: Build borgmatic image
+  community.docker.docker_image:
+    name: datalab-borgmatic
+    source: build
+    state: present
+    force_source: true
+    build:
+      path: "{{ ansible_user_home_dir }}/borgmatic"
+
 - name: Create borg repository if it does not exist
   ansible.builtin.shell:
-    cmd: source {{ ansible_user_home_dir }}/.profile && borgmatic init --encryption=repokey
+    cmd: docker run --network datalab_backend -v {{ ansible_user_home_dir }}/borgmatic/.ssh:/root/.ssh -v /data:/data datalab-borgmatic borgmatic init --encryption=repokey
+      -c /etc/borgmatic/config.yaml
     executable: /bin/bash
   register: new_borg_repository
   changed_when: '"Repository already exists" not in new_borg_repository.stdout'
@@ -79,7 +77,7 @@
 
 - name: Perform first backup if borg repo was just created
   ansible.builtin.shell:
-    cmd: source {{ ansible_user_home_dir }}/.profile && borgmatic -c /etc/borgmatic/config.yaml # noqa: no-changed-when
+    cmd: docker run --network datalab_backend -v {{ ansible_user_home_dir }}/borgmatic/.ssh:/root/.ssh -v /data:/data datalab-borgmatic # noqa: no-changed-when
     executable: /bin/bash
   when: new_borg_repository.changed # noqa: no-handler
 
@@ -89,4 +87,4 @@
     hour: "2"
     minute: "{{ range(0, 59) | random(seed=inventory_hostname) }}"
     user: "{{ ansible_user }}"
-    job: /bin/bash -l -c 'source {{ ansible_user_home_dir }}/.profile && borgmatic -c /etc/borgmatic/config.yaml'
+    job: docker run --network datalab_backend -v {{ ansible_user_home_dir }}/borgmatic/.ssh:/root/.ssh -v /data:/data datalab-borgmatic

--- a/ansible/roles/datalab/tasks/main.yml
+++ b/ansible/roles/datalab/tasks/main.yml
@@ -100,7 +100,7 @@
     name: Weekly snapshots
     minute: "5"
     hour: "5"
-    day: "7"
+    weekday: "7"
     month: "*"
     job: cd {{ ansible_user_home_dir }}/datalab; docker compose exec api /opt/.venv/bin/python -m invoke admin.create-backup --strategy-name weekly-snapshots
 

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,24 +1,34 @@
 ---
+- name: Check whether Docker is already installed
+  ansible.builtin.command:
+    cmd: docker --version # noqa: no-changed-when
+  register: docker_version
+  ignore_errors: true
+
 - name: Add Docker GPG apt Key
   become: true
+  when: docker_version.failed
   ansible.builtin.apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg
     state: present
 
 - name: Add Docker Repository
   become: true
+  when: docker_version.failed
   ansible.builtin.apt_repository:
     repo: deb https://download.docker.com/linux/ubuntu focal stable
     state: present
 
 - name: Update apt and install docker-ce
   become: true
+  when: docker_version.failed
   ansible.builtin.apt:
     name: docker-ce
     state: present
     update_cache: true
 
 - name: Install Docker Module for Python
+  when: docker_version.failed
   ansible.builtin.pip:
     name: docker
     break_system_packages: true

--- a/ansible/roles/preflight/tasks/main.yml
+++ b/ansible/roles/preflight/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Check OS is compatible
+  ansible.builtin.fail:
+    msg: This role is only compatible with Ubuntu 22.04/24.04
+  when: ansible_distribution != 'Ubuntu' or ansible_distribution_version != '22.04' and ansible_distribution_version != '24.04'

--- a/ansible/roles/setup/tasks/main.yml
+++ b/ansible/roles/setup/tasks/main.yml
@@ -15,8 +15,19 @@
     state: present
     update_cache: true
 
-- name: Install required system packages
+- name: Install required system packages (24.04)
   become: true
+  when: ansible_distribution_version == '24.04'
+  ansible.builtin.apt:
+    pkg:
+      - ca-certificates
+      - python3-pip
+    state: present
+    update_cache: true
+
+- name: Install required system packages (22.04)
+  become: true
+  when: ansible_distribution_version == '22.04'
   ansible.builtin.apt:
     pkg:
       - ca-certificates

--- a/ansible/roles/ssl_first_run/files/Dockerfile
+++ b/ansible/roles/ssl_first_run/files/Dockerfile
@@ -3,8 +3,6 @@ FROM nginx:1.25.3
 WORKDIR /app
 
 COPY nginx.conf /etc/nginx/nginx.conf
-COPY ./rendered/nginx_ssl.conf /etc/nginx/nginx_ssl.conf
-COPY ./rendered/include /etc/nginx/include
 RUN rm -f /etc/nginx/conf.d/default.conf
 
 

--- a/ansible/roles/ssl_first_run/files/nginx.conf
+++ b/ansible/roles/ssl_first_run/files/nginx.conf
@@ -21,11 +21,6 @@ http {
   add_header X-XSS-Protection "1; mode=block;";
   add_header X-Content-Type-Options "nosniff;";
 
-  # Include upstream definitions
-  # When SSL needs to be nuked, comment out this line and regenerate certs
-  # include /etc/nginx/include/*;
-
-  # Proxy all HTTP requests to the HTTPS server
   server {
       listen 80;
       listen [::]:80;

--- a/ansible/roles/ssl_first_run/tasks/main.yml
+++ b/ansible/roles/ssl_first_run/tasks/main.yml
@@ -19,6 +19,12 @@
     src: "{{ role_path }}/files/"
     dest: "{{ ansible_user_home_dir }}/nginx"
 
+- name: Make directory for rendered configs
+  ansible.builtin.file:
+    state: directory
+    path: "{{ ansible_user_home_dir }}/nginx/rendered"
+    mode: "0744"
+
 - name: Render templated certbot config
   ansible.builtin.template:
     src: certbot-docker.sh.j2


### PR DESCRIPTION
This PR containerises the borg backup system to avoid needing to expose local ports.

It also:

- Closes #19, by only installing docker if it is missing
- Adds a preflight check for support OS versions
- Updates datalab to v0.5.0-rc.4
- Fixes the edge case where SSL certs are set up before first nginx run