### PR TITLE
Add nginx reload task to SSL cron to fix automated cert refresh

### DIFF
--- a/ansible/roles/ssl_first_run/tasks/main.yml
+++ b/ansible/roles/ssl_first_run/tasks/main.yml
@@ -71,4 +71,4 @@
     hour: "10"
     weekday: "2"
     month: "*"
-    job: docker run -v certbot-www:/var/www/certbot -v certbot-conf:/etc/letsencrypt certbot/certbot:latest renew
+    job: docker run -v certbot-www:/var/www/certbot -v certbot-conf:/etc/letsencrypt certbot/certbot:latest renew && docker exec datalab-nginx nginx -s reload


### PR DESCRIPTION
This should fix intermittent issues with certs not refreshing after SSL renewal.